### PR TITLE
FIX #84

### DIFF
--- a/sphinx/screens/dashboard/dashboard/src/main/java/chat/sphinx/dashboard/ui/adapter/DashboardChat.kt
+++ b/sphinx/screens/dashboard/dashboard/src/main/java/chat/sphinx/dashboard/ui/adapter/DashboardChat.kt
@@ -323,9 +323,15 @@ sealed class DashboardChat {
                 get() = chat.photoUrl ?: contact.photoUrl
 
             override fun getMessageSender(message: Message, context: Context, withColon: Boolean): String {
-                return contact.alias?.let { alias ->
-                    alias.value + if (withColon) ": " else ""
-                } ?: ""
+                return if (isMessageSenderSelf(message)) {
+
+                    context.getString(R.string.last_message_description_you) + if (withColon) ": " else ""
+                } else {
+
+                    contact.alias?.let { alias ->
+                        alias.value + if (withColon) ": " else ""
+                    } ?: ""
+                }
             }
 
             override fun getColorKey(): String? {


### PR DESCRIPTION
Fixed Wrong sender on Chat list message preview. Now shows You:
![Screenshot 2025-02-04 101302](https://github.com/user-attachments/assets/919be5cc-d109-4bd0-99a9-63c51bcd1b09)
![Screenshot 2025-02-04 101454](https://github.com/user-attachments/assets/ca2ee78c-6b87-4aec-a69e-77de527d8e9c)
